### PR TITLE
Allows users to select their own cooling temp

### DIFF
--- a/src/cshock.f90
+++ b/src/cshock.f90
@@ -33,7 +33,7 @@ MODULE physics
     double precision :: grainRadius5,dens6,grainNumberDensity,dzv,start_vel
     double precision, allocatable :: tn(:),ti(:),tgc(:),tgr(:),tg(:)
     integer :: manCoolTemp, postShock
-    double precision :: coolTemp
+    double precision, parameter :: coolTemp=100.0
     !variables for the collisional and radiative heating of grains
     double precision :: mun,tgc0,Frs,tgr0,tgr1,tgr2,tau100,trs0,G0
     double precision :: coshinv1,coshinv2,zmax,a1,eta,eps,epso,sConst
@@ -60,6 +60,9 @@ CONTAINS
         driftVel=0.0
         zn0=0.0
         vn0=0.0
+
+        ! Set cooling variables to off by default (change if reqd)
+        manCoolTemp = 0
 
         !check input sanity and set inital values
         cloudSize=(rout-rin)*pc

--- a/src/cshock.f90
+++ b/src/cshock.f90
@@ -32,6 +32,8 @@ MODULE physics
     double precision :: ucm,z1,driftVel,vi,tempi,vn0,zn0,vA,dlength
     double precision :: grainRadius5,dens6,grainNumberDensity,dzv,start_vel
     double precision, allocatable :: tn(:),ti(:),tgc(:),tgr(:),tg(:)
+    integer :: manCoolTemp, postShock
+    double precision :: coolTemp
     !variables for the collisional and radiative heating of grains
     double precision :: mun,tgc0,Frs,tgr0,tgr1,tgr2,tau100,trs0,G0
     double precision :: coshinv1,coshinv2,zmax,a1,eta,eps,epso,sConst
@@ -265,7 +267,16 @@ CONTAINS
                 temp(dstep)=tn(dstep)
                 ti(dstep)=tn(dstep)+(mun*(driftVel*km)**2/(3*K_BOLTZ_CGS))
                 tempi=ti(dstep)
+
+                IF ((temp(dstep) .gt. coolTemp) .AND. (manCoolTemp .eq. 1)) THEN
+                    postShock = 1
+                END IF
             ENDIF
+
+            IF ((temp(dstep) .lt. coolTemp) .AND. (phase .eq. 2) .AND. (postShock .eq. 1)) THEN
+                temp(dstep) = coolTemp
+            END IF
+            
         ENDIF
     END SUBROUTINE updatePhysics
 

--- a/src/defaultparameters.f90
+++ b/src/defaultparameters.f90
@@ -58,8 +58,6 @@ tempindx=3
 
 !cshock module specific variable, uncomment or comment as  needed
 vs=40.0
-manCoolTemp=0 ! Binary switch to enable manual cooling to desired temp
-coolTemp=100.0 ! Desired cooling temp - will not be active unless manCoolTemp=1
 
 !initial fractional abundances of elements(from Asplund et al. 2009 ARAA table 1 -SOLAR)
 fh=0.0;fhe = 0.1;fc  = 2.6d-04;fo  = 4.6d-04;fn  = 6.1d-05

--- a/src/defaultparameters.f90
+++ b/src/defaultparameters.f90
@@ -58,6 +58,8 @@ tempindx=3
 
 !cshock module specific variable, uncomment or comment as  needed
 vs=40.0
+manCoolTemp=0 ! Binary switch to enable manual cooling to desired temp
+coolTemp=100.0 ! Desired cooling temp - will not be active unless manCoolTemp=1
 
 !initial fractional abundances of elements(from Asplund et al. 2009 ARAA table 1 -SOLAR)
 fh=0.0;fhe = 0.1;fc  = 2.6d-04;fo  = 4.6d-04;fn  = 6.1d-05


### PR DESCRIPTION
Switch has been added to defaultparameters.f90 to activate this. When active, will set the final temperature of the shock (i.e. its equilibrium temperature) to be the value defined in defaultparameters.f90.