### PR TITLE
Pytest fixes, Path fix and faster pip install

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,7 +1,7 @@
 name: Run pytest
 
 on:
-  push:
+  pull_request:
     branches:
       - main
       - develop  # Add the 'develop' branch here

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.10  # Specify the Python version you need
+        python-version: "3.10"  # Specify the Python version you need
 
     - name: Install gfortran
       run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -27,6 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install pytest
     
     - name: Install package in editable mode
       run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -27,7 +27,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt  # Replace with the path to your requirements file
     
     - name: Install package in editable mode
       run: |

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import setuptools  # this is the "magic" import
 import subprocess
 import sys
 
@@ -9,17 +8,20 @@ from shutil import move
 
 #make clean every time slows things but is needed because users will mostly install after changing networks
 #and a make never seems to full update the new network
-cwd = os.getcwd()
-os.chdir('src/fortran_src/')
-result = subprocess.call('make clean', shell=True)
-# if result != 0:
-#     exit(1)
-result = subprocess.call('make python', shell=True)
-if result != 0:
-    exit(1)
-os.chdir(cwd)
+# print(f"STAGE: {sys.argv[1]}, full command: {sys.argv}")
+if sys.argv[1] in ("editable_wheel"):
+    cwd = os.getcwd()
+    os.chdir('src/fortran_src/')
+    _ = subprocess.call('make clean', shell=True)
+    result = subprocess.call('make python', shell=True)
+    if result != 0:
+        exit(1)
+    os.chdir(cwd)
 
-wrap_file = glob("src/fortran_src/uclchemwrap*.so")[0]
-move(wrap_file, "src/uclchem/uclchemwrap.so")
-
+    wrap_file = glob("src/fortran_src/uclchemwrap*.so")[0]
+    move(wrap_file, "src/uclchem/uclchemwrap.so")
+elif sys.argv[1] in ("bdist_wheel"):
+    raise RuntimeError("Cannot install UCLCHEM in the site packages, use `pip install -e .`")
+else:
+    pass
 setup()

--- a/src/uclchem/makerates/io_functions.py
+++ b/src/uclchem/makerates/io_functions.py
@@ -215,6 +215,7 @@ def write_outputs(network: Network, output_dir: str = None) -> None:
         output_dir = Path("../src/uclchem")
         fortran_src_dir = Path("../src/fortran_src")
     else:
+        output_dir = Path(output_dir)
         fortran_src_dir = Path(output_dir)
 
     # Create the species file


### PR DESCRIPTION
- Made a small fix where by specifying a custom path for makerates, one could try to str / str (which gives an error).
- Made sure we now check whether you are installing or just gathering info, only letting you compile once, and we now throw an error when you try the old install method `pip install .` Close #41 
- Fixed some issues with the github actions, a limited number of tests now runs for every PR.