### PR TITLE
Magnetic parameter bm0 added as a new default parameter

### DIFF
--- a/src/fortran_src/cshock.f90
+++ b/src/fortran_src/cshock.f90
@@ -21,7 +21,7 @@ MODULE cshock_mod
     REAL(dp) :: coshinv1,coshinv2,zmax,a1,eps
 
     INTEGER :: inrad
-    REAL(dp), PARAMETER ::nu0=3.0d15,bm0=1.e-6,bt=6.
+    REAL(dp), PARAMETER ::nu0=3.0d15,bt=6.
     REAL(dp), PARAMETER :: grainRadius=1.0d-5
 
 CONTAINS
@@ -116,6 +116,7 @@ CONTAINS
         !For the general case, the Alfven velocity is calculated as vA=B0/sqrt(4*pi*2*initialDens). If we
         !substitute the expression of B0 on this equation, we obtain that vA=bm0/sqrt(4*pi*mH).
         !B0=bm0*sqrt(2*initialDens)
+        bm0 = bm0*1D-06
         vA=bm0/sqrt(4*pi*mh)
         vA=vA/km
 

--- a/src/fortran_src/defaultparameters.f90
+++ b/src/fortran_src/defaultparameters.f90
@@ -25,6 +25,7 @@ rout=0.05 !Outer radius of cloud being modelled in pc.
 rin=0.0 !Minimum radial distance from cloud centre to consider.
 baseAv=2.0 !Extinction at cloud edge, Av of a parcel at rout.
 points=1 !Number of gas parcels equally spaced between rin to rout to consider
+bm0=1 !magnetic parameter [microgauss]: B0 = bm0*sqrt(initialDens)
 !
 !## Behavioural Controls
 !*The following parameters generally turn on or off features of the model. If a parameter is set to `True`, then it is turned on. If it is set to `False`, then it is turned off.*

--- a/src/fortran_src/physics-core.f90
+++ b/src/fortran_src/physics-core.f90
@@ -21,7 +21,7 @@ MODULE physicscore
 
     !variables either controlled by physics or that user may wish to change
     REAL(dp) :: initialDens,timeInYears,targetTime,currentTime,currentTimeold,finalDens,finalTime,initialTemp
-    REAL(dp) ::  freefallFactor,cloudSize,rout,rin,baseAv,zeta
+    REAL(dp) ::  freefallFactor,cloudSize,rout,rin,baseAv,zeta,bm0
     REAL(dp), allocatable :: av(:),coldens(:),gasTemp(:),dustTemp(:),density(:)
 
     !Arrays fopr calculating rates

--- a/src/fortran_src/wrap.f90
+++ b/src/fortran_src/wrap.f90
@@ -669,6 +669,8 @@ CONTAINS
                     READ(inputValue,*,iostat=successFlag) baseAv
                 CASE('points')
                     READ(inputValue,*,iostat=successFlag) points
+                CASE('bm0')
+                    READ(inputValue,*,iostat=successFlag) bm0
                 CASE('endatfinaldensity')
                     Read(inputValue,*,iostat=successFlag) endAtFinalDensity
                 CASE('freefall')


### PR DESCRIPTION
Changes to cshock.f90, wrap.f90, defaultparameters.f90, and physics-core.f90. 
New usage - bm0 is now a multiplication factor. Since bm0 is only used in the cshock.f90, the shock module deals with the recalculation to microGauss. 