### PR TITLE
Add smaller than 2 dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,6 @@ readme = "README.md"
 requires-python = ">=3.9,<3.12"
 license = {text = "MIT License"}
 dependencies = [
-    "pandas", "numpy", "pyyaml", "matplotlib", "seaborn", "pytest"
+    "pandas<2", "numpy<2", "pyyaml", "matplotlib", "seaborn", "pytest"
 ]
 


### PR DESCRIPTION
Until numpy and pandas are proven to play nice with uclchem, don't use version 2 of either.