### PR TITLE
Constrain dependencies further

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm", "numpy", "wheel", "setuptools-git-versioning<2"]
+requires = ["setuptools>64,<74", "setuptools-scm", "numpy<2", "wheel", "setuptools-git-versioning<2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools-git-versioning]


### PR DESCRIPTION
Until we can migrate from setuptools to meson or another build system, we need to put further constraints on version to keep UCLCHEM compileable. 

This fix is derived from here:
https://github.com/diofant/diofant/commit/568d6dab77d941a2588cdd7c4880fc2384cf4bfb And others are facing similar issues, as can be seen here: https://github.com/pypa/setuptools/issues/3329