### PR TITLE
Assign specName to specname_out in postprocess

### DIFF
--- a/src/fortran_src/wrap.f90
+++ b/src/fortran_src/wrap.f90
@@ -436,7 +436,7 @@ CONTAINS
                 &timegrid,densgrid,gastempgrid,dusttempgrid,radfieldgrid,zetagrid,&
                 &usecoldens)
         end if
-        
+        specname_out(:nspec) = specName
         IF ((ALLOCATED(outIndx)) .and. (successFlag .eq. 0)) THEN 
             abundance_out(1:SIZE(outIndx))=abund(outIndx,1)
         END IF 


### PR DESCRIPTION
Small fix to bug that can cause crashes if used via model.py