### PR TITLE
Force explicit input name for save and load model

### DIFF
--- a/src/uclchem/model.py
+++ b/src/uclchem/model.py
@@ -208,6 +208,7 @@ get_species_names = SpeciesNameStore()
 
 # Universal model loader
 def load_model(
+    *,
     file_obj: h5py.File = None,
     file: str = None,
     name: str = "default",
@@ -1191,6 +1192,7 @@ class AbstractModel(ABC):
     # Model saving
     def save_model(
         self,
+        *,
         file_obj: h5py.File = None,
         file: str = None,
         name: str = "default",
@@ -2969,6 +2971,7 @@ class SequentialModel:
 
     def save_model(
         self,
+        *,
         file_obj: h5py.File = None,
         file: str = None,
         name: str = "",


### PR DESCRIPTION
Previously, errors could arise if users were unaware of how to pass file path, instead of already open h5py.File object. Now, users must explicitly name input parameters for save_model and load_model methods.