### PR TITLE
Fix KIDA reaction network parsing

### DIFF
--- a/src/uclchem/makerates/io_functions.py
+++ b/src/uclchem/makerates/io_functions.py
@@ -15,7 +15,6 @@ import yaml
 
 from uclchem.utils import UCLCHEM_ROOT_DIR
 
-from typing import Any
 from .network import Network
 from .reaction import Reaction, reaction_types
 from .species import Species, species_header
@@ -1319,9 +1318,7 @@ def write_network_file(
         openFile.write("    REAL(dp) :: REACTIONRATE(1)\n")
         openFile.write("    LOGICAL :: storeRatesComputation=.false.\n")
     if any(exo != 0.0 for exo in exothermicity):
-        assert enable_rates_storage, (
-            "Chemical heating can only be enabled if rates are being computed and stored in memory. Enable `enable_rates_storage` in the user_settings."
-        )
+        assert enable_rates_storage, "Chemical heating can only be enabled if rates are being computed and stored in memory. Enable `enable_rates_storage` in the user_settings."
         openFile.write(
             array_to_string(
                 "\texothermicities", exothermicity, type="float", parameter=True

--- a/src/uclchem/makerates/io_functions.py
+++ b/src/uclchem/makerates/io_functions.py
@@ -15,6 +15,7 @@ import yaml
 
 from uclchem.utils import UCLCHEM_ROOT_DIR
 
+from typing import Any
 from .network import Network
 from .reaction import Reaction, reaction_types
 from .species import Species, species_header
@@ -178,8 +179,10 @@ def check_reaction(reaction_row, keep_list) -> bool:
         if reaction_row[10] == "":
             reaction_row[10] = 0.0
             reaction_row[11] = 10000.0
-        if reaction_row[12] == "":
+        if len(reaction_row) >= 13 and reaction_row[12] == "":
             reaction_row[12] = 0.0
+        if len(reaction_row) >= 14 and reaction_row[13] == "":
+            reaction_row[13] = False
         return True
     else:
         if reaction_row[1] in ["DESORB", "FREEZE"]:
@@ -189,7 +192,7 @@ def check_reaction(reaction_row, keep_list) -> bool:
         return False
 
 
-def kida_parser(kida_file):
+def kida_parser(kida_file: str | Path) -> list[list[str | float | int]]:
     """
     KIDA used a fixed format file so we read each line in the chunks they specify
     and use python built in classes to convert to the necessary types.
@@ -436,10 +439,10 @@ def write_outputs(
         logging.info(f"  {'-' * name_width}  {'-' * 10}")
         for name, dev in sorted_devs:
             marker = " <<<" if dev > 0.01 else ""
-            logging.info(f"  {name:<{name_width}}  {dev*100:9.4f}%{marker}")
+            logging.info(f"  {name:<{name_width}}  {dev * 100:9.4f}%{marker}")
         logging.info(
             f"  Auto-setting freq_rel_tol = {suggested_freq_rel_tol:.4f} "
-            f"(max deviation {max_deviation*100:.2f}% + 10% margin)"
+            f"(max deviation {max_deviation * 100:.2f}% + 10% margin)"
         )
     else:
         suggested_freq_rel_tol = 0.01
@@ -501,7 +504,7 @@ def write_outputs(
     if missing_parents:
         error_msg = "ERROR: The following coolants reference parent species that don't exist in the network:\n"
         for idx, coolant_name, parent_name in missing_parents:
-            error_msg += f"  - Coolant #{idx+1} '{coolant_name}' → parent species '{parent_name}' not found\n"
+            error_msg += f"  - Coolant #{idx + 1} '{coolant_name}' → parent species '{parent_name}' not found\n"
         error_msg += (
             "\nAvailable species: "
             + ", ".join(sorted(species_dict.keys())[:20])
@@ -1316,7 +1319,9 @@ def write_network_file(
         openFile.write("    REAL(dp) :: REACTIONRATE(1)\n")
         openFile.write("    LOGICAL :: storeRatesComputation=.false.\n")
     if any(exo != 0.0 for exo in exothermicity):
-        assert enable_rates_storage, "Chemical heating can only be enabled if rates are being computed and stored in memory. Enable `enable_rates_storage` in the user_settings."
+        assert enable_rates_storage, (
+            "Chemical heating can only be enabled if rates are being computed and stored in memory. Enable `enable_rates_storage` in the user_settings."
+        )
         openFile.write(
             array_to_string(
                 "\texothermicities", exothermicity, type="float", parameter=True

--- a/src/uclchem/makerates/network.py
+++ b/src/uclchem/makerates/network.py
@@ -621,9 +621,9 @@ class Network(BaseNetwork, MutableNetworkABC):
         """Set/update a reaction at specific index."""
         old_length = len(self._reactions_dict)
         self._reactions_dict[reaction_idx] = reaction
-        assert old_length == len(self._reactions_dict), (
-            "Setting the reaction caused a change in the number of reactions"
-        )
+        assert old_length == len(
+            self._reactions_dict
+        ), "Setting the reaction caused a change in the number of reactions"
 
     def set_reaction_dict(self, new_dict: dict[int, Reaction]) -> None:
         """Replace entire reaction dictionary."""
@@ -723,9 +723,9 @@ class Network(BaseNetwork, MutableNetworkABC):
                 )
             )
         )
-        assert len(reaction_dict) == len(self.get_reaction_dict()), (
-            "Sorting the species caused a difference in the number of species"
-        )
+        assert len(reaction_dict) == len(
+            self.get_reaction_dict()
+        ), "Sorting the species caused a difference in the number of species"
 
     # Note: Query methods (find_similar_reactions, get_reaction_index, etc.)
     # are inherited from BaseNetwork

--- a/src/uclchem/makerates/network.py
+++ b/src/uclchem/makerates/network.py
@@ -503,7 +503,7 @@ class Network(BaseNetwork, MutableNetworkABC):
             ...     add_crp_photo_to_grain=True
             ... )
         """
-        from .network_builder import NetworkBuilder
+        from uclchem.makerates.network_builder import NetworkBuilder
 
         builder = NetworkBuilder(species, reactions, **build_options)
         return builder.build()
@@ -621,9 +621,9 @@ class Network(BaseNetwork, MutableNetworkABC):
         """Set/update a reaction at specific index."""
         old_length = len(self._reactions_dict)
         self._reactions_dict[reaction_idx] = reaction
-        assert old_length == len(
-            self._reactions_dict
-        ), "Setting the reaction caused a change in the number of reactions"
+        assert old_length == len(self._reactions_dict), (
+            "Setting the reaction caused a change in the number of reactions"
+        )
 
     def set_reaction_dict(self, new_dict: dict[int, Reaction]) -> None:
         """Replace entire reaction dictionary."""
@@ -723,9 +723,9 @@ class Network(BaseNetwork, MutableNetworkABC):
                 )
             )
         )
-        assert len(reaction_dict) == len(
-            self.get_reaction_dict()
-        ), "Sorting the species caused a difference in the number of species"
+        assert len(reaction_dict) == len(self.get_reaction_dict()), (
+            "Sorting the species caused a difference in the number of species"
+        )
 
     # Note: Query methods (find_similar_reactions, get_reaction_index, etc.)
     # are inherited from BaseNetwork
@@ -852,7 +852,7 @@ def build_network(
         species: List of Species objects
         reactions: List of Reaction objects
         user_defined_bulk: User-specified bulk species (optional)
-        gas_phase_extrapolation: Extrapolate gas-phase reactions to grain
+        gas_phase_extrapolation: Extrapolate gas-phase reactions temperatures
         add_crp_photo_to_grain: Add CRP/PHOTON reactions to grain surface
         derive_reaction_exothermicity: Reaction types to calculate exothermicity for
         database_reaction_exothermicity: Custom exothermicity database files

--- a/src/uclchem/makerates/network_builder.py
+++ b/src/uclchem/makerates/network_builder.py
@@ -71,9 +71,9 @@ class NetworkBuilder:
             AssertionError: If duplicate species are provided
         """
         # Validate inputs
-        assert len({s.get_name() for s in species}) == len(species), (
-            "Cannot have duplicate species in the species list."
-        )
+        assert len({s.get_name() for s in species}) == len(
+            species
+        ), "Cannot have duplicate species in the species list."
 
         # Store inputs
         self.input_species = species

--- a/src/uclchem/makerates/network_builder.py
+++ b/src/uclchem/makerates/network_builder.py
@@ -62,7 +62,7 @@ class NetworkBuilder:
             species: List of chemical species
             reactions: List of chemical reactions
             user_defined_bulk: User-specified bulk species (optional)
-            gas_phase_extrapolation: Extrapolate gas-phase to grain (default: False)
+            gas_phase_extrapolation: Extrapolate gas-phase temperature (default: False)
             add_crp_photo_to_grain: Add CRP/PHOTON to grain (default: False)
             derive_reaction_exothermicity: Reaction types to calculate exothermicity for
             database_reaction_exothermicity: Custom exothermicity database files
@@ -71,9 +71,9 @@ class NetworkBuilder:
             AssertionError: If duplicate species are provided
         """
         # Validate inputs
-        assert len({s.get_name() for s in species}) == len(
-            species
-        ), "Cannot have duplicate species in the species list."
+        assert len({s.get_name() for s in species}) == len(species), (
+            "Cannot have duplicate species in the species list."
+        )
 
         # Store inputs
         self.input_species = species

--- a/src/uclchem/makerates/reaction.py
+++ b/src/uclchem/makerates/reaction.py
@@ -704,9 +704,9 @@ class Reaction:
         return formatted_reaction
 
     def _is_reaction_wrap(self, include_reactants=True, include_products=True):
-        assert include_reactants or include_products, (
-            "Either include reactants or products"
-        )
+        assert (
+            include_reactants or include_products
+        ), "Either include reactants or products"
         species_to_check = []
         if include_reactants:
             species_to_check += self.get_pure_reactants()

--- a/src/uclchem/makerates/reaction.py
+++ b/src/uclchem/makerates/reaction.py
@@ -120,6 +120,8 @@ class Reaction:
                 self.set_temphigh(float(inputRow[11]))
                 if len(inputRow) > 12:
                     self.set_reduced_mass(float(inputRow[12]))
+                else:
+                    self.set_reduced_mass(0.0)
                 self.set_extrapolation(
                     bool(inputRow[13]) if len(inputRow) > 13 else False
                 )
@@ -702,9 +704,9 @@ class Reaction:
         return formatted_reaction
 
     def _is_reaction_wrap(self, include_reactants=True, include_products=True):
-        assert (
-            include_reactants or include_products
-        ), "Either include reactants or products"
+        assert include_reactants or include_products, (
+            "Either include reactants or products"
+        )
         species_to_check = []
         if include_reactants:
             species_to_check += self.get_pure_reactants()


### PR DESCRIPTION
KIDA parsing was broken since the introduction of custom reduced masses for tunneling reactions (see #102).
This should fix it, by setting the reduced mass to 0. It is not important anyway for non-tunneling (i.e. any reaction except LH and ER reactions at this moment).