### PR TITLE
Throw error if there are gas-phase products in a grain-based reaction

### DIFF
--- a/src/uclchem/makerates/network_builder.py
+++ b/src/uclchem/makerates/network_builder.py
@@ -512,7 +512,7 @@ class NetworkBuilder:
                         prod.startswith("#") or prod.startswith("@")
                         for prod in new_products
                     ) != len(new_products):
-                        logging.warning(
+                        raise ValueError(
                             "All Langmuir-Hinshelwood and Eley-Rideal reactions should be input with products on grains only.\n"
                             + "The fraction of products that enter the gas is dealt with by Makerates and UCLCHEM.\n"
                             + "the following reaction caused this warning\t"


### PR DESCRIPTION
Throw error if there are gas-phase products in an LH or ER reaction.
If we do not do this, there is an error if we try to create the CHEMDES reactions, e.g.
 #H + #H (LH) -> H2
will try to create LHDES reaction where H2 desorbs, but H2 of course has no desorption products, so gets an error.