### PR TITLE
Remove kwarg 'previous_model', and combine it into 'starting_chemistry' for easier API

### DIFF
--- a/notebooks/2b_modelling_objects_in_memory.py
+++ b/notebooks/2b_modelling_objects_in_memory.py
@@ -78,7 +78,7 @@ param_dict["abstol_factor"] = 1e-18
 param_dict["reltol"] = 1e-12
 
 p_core = uclchem.model.PrestellarCore(
-    temp_indx=3, max_temperature=300.0, param_dict=param_dict, previous_model=cloud
+    temp_indx=3, max_temperature=300.0, param_dict=param_dict, starting_chemistry=cloud
 )
 p_core.check_conservation()
 # -
@@ -163,7 +163,7 @@ shock_start.check_conservation()
 param_dict["initialDens"] = 1e4
 param_dict["finalTime"] = 1e6
 cshock = uclchem.model.CShock(
-    shock_vel=40, param_dict=param_dict, previous_model=shock_start
+    shock_vel=40, param_dict=param_dict, starting_chemistry=shock_start
 )
 cshock.check_conservation()
 
@@ -206,7 +206,7 @@ shock_vel = 10.0
 jshock = uclchem.model.JShock(
     shock_vel=shock_vel,
     param_dict=param_dict,
-    previous_model=shock_start,
+    starting_chemistry=shock_start,
     timepoints=1500,
 )
 
@@ -248,6 +248,6 @@ ax3.tick_params(axis="y", colors="red")
 # a real cloud. Testing whether your results are sensitive to things like the time you run the preliminary for or the
 # exact density is a good way to make sure these approximations are not problematic.
 #
-# Bear in mind that all model objects can be passed as inputs to `previous_model`. This lets you chain model runs
+# Bear in mind that all model objects can be passed as inputs to `starting_chemistry`. This lets you chain model runs
 # together. For example, you could run a c-shock from a cloud model as we did here and then a j-shock with the c-shock
 # object as the previous model.

--- a/notebooks/2c_save_load_model_objects.py
+++ b/notebooks/2c_save_load_model_objects.py
@@ -63,7 +63,7 @@ param_dict["abstol_factor"] = 1e-18
 param_dict["reltol"] = 1e-12
 
 p_core = uclchem.model.PrestellarCore(
-    temp_indx=3, max_temperature=300.0, param_dict=param_dict, previous_model=cloud
+    temp_indx=3, max_temperature=300.0, param_dict=param_dict, starting_chemistry==cloud
 )
 p_core.save_model(file=save_file, name="prestellar_core", overwrite=True)
 
@@ -96,7 +96,7 @@ param_dict["initialDens"] = 1e4
 param_dict["finalTime"] = 1e6
 
 cshock = uclchem.model.CShock(
-    shock_vel=40, param_dict=param_dict, previous_model=shock_start
+    shock_vel=40, param_dict=param_dict, starting_chemistry=shock_start
 )
 cshock.save_model(file=save_file, name="cshock", overwrite=True)
 
@@ -105,7 +105,7 @@ param_dict["freefall"] = False  # lets remember to turn it off this time
 param_dict["reltol"] = 1e-12
 
 jshock = uclchem.model.JShock(
-    shock_vel=10.0, param_dict=param_dict, previous_model=shock_start, timepoints=1500
+    shock_vel=10.0, param_dict=param_dict, starting_chemistry=shock_start, timepoints=1500
 )
 jshock.save_model(file=save_file, name="jshock", overwrite=True)
 

--- a/src/uclchem/functional.py
+++ b/src/uclchem/functional.py
@@ -89,7 +89,7 @@ def __validate_functional_api_params__(
     return_dataframe: bool,
     return_rate_constants: bool,
     return_heating: bool,
-    starting_chemistry: np.ndarray,  # noqa: ARG001
+    starting_chemistry: np.ndarray | AbstractModel,  # noqa: ARG001
     return_stats: bool = False,
 ) -> None:
     """Validate functional API specific constraints.
@@ -318,7 +318,7 @@ def __cloud__(
     return_rate_constants: bool = False,
     return_heating: bool = False,
     return_stats: bool = False,
-    starting_chemistry: np.ndarray | None = None,
+    starting_chemistry: np.ndarray | AbstractModel | None = None,
     timepoints: int = TIMEPOINTS,
 ):
     """Run cloud model from UCLCHEM.
@@ -340,8 +340,9 @@ def __cloud__(
         return_heating (bool): A boolean on whether the heating/cooling arrays should
             be returned to a user.
         return_stats (bool): Whether DVODE statistics should be returned. Default = False.
-        starting_chemistry (np.ndarray): Array containing the starting chemical abundances
-            needed by uclchem.
+        starting_chemistry (np.ndarray | AbstractModel | None): Array containing the starting abundances
+            to use for the UCLCHEM model or :class:`AbstractModel` instance to take final
+            abundances from. Defaults to None.
         timepoints (int): Integer value of how many timesteps should be calculated before
             aborting the UCLCHEM model. Defaults to `uclchem.constants.TIMEPOINTS`.
 
@@ -419,7 +420,7 @@ def __collapse__(
     return_rate_constants: bool = False,
     return_heating: bool = False,
     return_stats: bool = False,
-    starting_chemistry: np.ndarray | None = None,
+    starting_chemistry: np.ndarray | AbstractModel | None = None,
     timepoints: int = TIMEPOINTS,
 ):
     """Run collapse model from UCLCHEM based on Priestley et al 2018 AJ 156 51 (https://ui.adsabs.harvard.edu/abs/2018AJ....156...51P/abstract).
@@ -443,8 +444,9 @@ def __collapse__(
         return_heating (bool): A boolean on whether the heating/cooling arrays should be
             returned to a user. Default = False.
         return_stats (bool): Whether DVODE statistics should be returned. Default = False.
-        starting_chemistry (np.ndarray): Array containing the starting chemical abundances
-            needed by UCLCHEM.
+        starting_chemistry (np.ndarray | AbstractModel | None): Array containing the starting abundances
+            to use for the UCLCHEM model or :class:`AbstractModel` instance to take final
+            abundances from. Defaults to None.
         timepoints (int): Integer value of how many timesteps should be calculated before aborting
             the UCLCHEM model. Defaults to `uclchem.constants.TIMEPOINTS`
 
@@ -522,7 +524,7 @@ def __prestellar_core__(
     return_rate_constants: bool = False,
     return_heating: bool = False,
     return_stats: bool = False,
-    starting_chemistry: np.ndarray | None = None,
+    starting_chemistry: np.ndarray | AbstractModel | None = None,
     timepoints: int = TIMEPOINTS,
 ):
     """Run prestellar core model from UCLCHEM, based on Viti et al. 2004 and Collings et al. 2004.
@@ -547,8 +549,9 @@ def __prestellar_core__(
         return_heating (bool): A boolean on whether the heating/cooling arrays should be
             returned to a user.
         return_stats (bool): Whether DVODE statistics should be returned. Default = False.
-        starting_chemistry (np.ndarray): Array containing the starting chemical abundances
-            needed by uclchem
+        starting_chemistry (np.ndarray | AbstractModel | None): Array containing the starting abundances
+            to use for the UCLCHEM model or :class:`AbstractModel` instance to take final
+            abundances from. Defaults to None.
         timepoints (int): Integer value of how many timesteps should be calculated before aborting
             the UCLCHEM model. Defaults to `uclchem.constants.TIMEPOINTS`.
 
@@ -629,7 +632,7 @@ def __cshock__(
     return_rate_constants: bool = False,
     return_heating: bool = False,
     return_stats: bool = False,
-    starting_chemistry: np.array = None,
+    starting_chemistry: np.ndarray | AbstractModel | None = None,
     timepoints: int = TIMEPOINTS,
 ):
     """Run C-type shock model from UCLCHEM.
@@ -655,8 +658,9 @@ def __cshock__(
         return_rate_constants (bool): Whether the reaction rate constants should be returned.
         return_heating (bool): Whether the heating/cooling arrays should be returned to a user.
         return_stats (bool): Whether DVODE statistics should be returned. Default = False.
-        starting_chemistry (np.ndarray): np.array containing the starting chemical abundances needed
-            by UCLCHEM.
+        starting_chemistry (np.ndarray | AbstractModel | None): Array containing the starting abundances
+            to use for the UCLCHEM model or :class:`AbstractModel` instance to take final
+            abundances from. Defaults to None.
         timepoints (int): Integer value of how many timesteps should be calculated before
             aborting the UCLCHEM model. Defaults to `uclchem.constants.TIMEPOINTS`.
 
@@ -740,7 +744,7 @@ def __jshock__(
     return_rate_constants: bool = False,
     return_heating: bool = False,
     return_stats: bool = False,
-    starting_chemistry: np.ndarray = None,
+    starting_chemistry: np.ndarray | AbstractModel | None = None,
     timepoints: int = TIMEPOINTS,
 ):
     """Run J-type shock model from UCLCHEM.
@@ -763,8 +767,9 @@ def __jshock__(
         return_heating (bool): A boolean on whether the heating/cooling arrays
             should be returned to a user. Default = False.
         return_stats (bool): Whether to return DVODE stats. Default = False.
-        starting_chemistry (np.ndarray | None): np.ndarray containing the starting
-            chemical abundances needed by UCLCHEM. Default = None.
+        starting_chemistry (np.ndarray | AbstractModel | None): Array containing the starting abundances
+            to use for the UCLCHEM model or :class:`AbstractModel` instance to take final
+            abundances from. Defaults to None.
         timepoints (int): Integer value of how many timesteps should be calculated
             before aborting the UCLCHEM model. Defaults to uclchem.constants.TIMEPOINTS
 

--- a/src/uclchem/model.py
+++ b/src/uclchem/model.py
@@ -4075,7 +4075,7 @@ class GridRunner:
 
                 # grid_param_dict contains the param_dict values of the next model to run.
                 grid_param_dict = {
-                    k: v if not isinstance(v, float) else v.item()
+                    k: v if not isinstance(v, float) else (v.item() if hasattr(v, 'item') else v)
                     for k, v in zip(param_keys, combo)
                     if k in full_parameters["param_dict"]
                 }

--- a/src/uclchem/model.py
+++ b/src/uclchem/model.py
@@ -45,9 +45,9 @@ Returns arrays/DataFrames instead of model objects.
 
 1. **Initialize**: Create model object with parameters
 2. **Run**: Model runs automatically on initialization (or use `read_file` to load)
-3. **Analyze**: Access results via attributes (`.final_abundances`, `.chemistry_dataframe`)
+3. **Analyze**: Access results via attributes (`.next_starting_chemistry_array`, `.get_dataframes()`)
 4. **Plot**: Use built-in plotting methods (`.create_abundance_plot()`)
-5. **Chain**: Use as input to next stage (`.previous_model` parameter)
+5. **Chain**: Use as input to next stage (`starting_chemistry` parameter)
 
 **Common Parameters:**
 
@@ -64,7 +64,7 @@ See the user guide for complete parameter list.
 **Species Naming:**
 
 - Gas phase: ``CO``, ``H2O``, ``CH3OH``
-- Ice surface: ``$CO``, ``$H2O``, ``$CH3OH``
+- Ice surface: ``#CO``, ``#H2O``, ``#CH3OH``
 - Ice bulk: ``@CO``, ``@H2O``, ``@CH3OH``
 
 **See Also:**
@@ -515,11 +515,11 @@ class AbstractModel(ABC):
             else None
         )
 
-        self.starting_chemistry_array = None
         if self.abundLoadFile is not None and starting_chemistry is not None:
             msg = "Both abundLoadFile and starting_chemistry were passed, but can only take one."
             raise ValueError(msg)
 
+        self.starting_chemistry_array = None
         if self.abundLoadFile is not None:
             self.legacy_read_starting_chemistry()
         else:

--- a/src/uclchem/model.py
+++ b/src/uclchem/model.py
@@ -417,11 +417,9 @@ class AbstractModel(ABC):
             Uses UCLCHEM default values if not provided.
         out_species_list (list[str] | None): List of species to focus on for outputs.
             If None, defaults to `uclchem.constants.default_elements_to_check`.
-        starting_chemistry (np.ndarray | None): Array containing the starting abundances to use for
-            the UCLCHEM model. Defaults to None.
-        previous_model (AbstractModel | None): Model object, a class that inherited from AbstractModel,
-            to use for the starting abundances of the new UCLCHEM model that will be run.
-            Defaults to None.
+        starting_chemistry (np.ndarray | AbstractModel | None): Array containing the starting abundances
+            to use for the UCLCHEM model or :class:`AbstractModel` instance to take final
+            abundances from. Defaults to None.
         timepoints (int): Integer value of how many timesteps should be calculated before
             aborting the UCLCHEM model. Defaults to `uclchem.constants.TIMEPOINTS`.
         debug (bool): Flag if extra debug information should be printed to the terminal.
@@ -437,8 +435,7 @@ class AbstractModel(ABC):
         self,
         param_dict: dict | None = None,
         out_species_list: list[str] | None = None,
-        starting_chemistry: np.ndarray | None = None,
-        previous_model: object | None = None,
+        starting_chemistry: np.ndarray | AbstractModel | None = None,
         timepoints: int = TIMEPOINTS,
         debug: bool = False,
         read_file: str | None = None,
@@ -519,17 +516,14 @@ class AbstractModel(ABC):
         )
 
         self.starting_chemistry_array = None
-        if previous_model is None and self.abundLoadFile is None:
-            self._create_starting_array(starting_chemistry)
-        elif self.abundLoadFile is not None:
+        if self.abundLoadFile is not None and starting_chemistry is not None:
+            msg = "Both abundLoadFile and starting_chemistry were passed, but can only take one."
+            raise ValueError(msg)
+
+        if self.abundLoadFile is not None:
             self.legacy_read_starting_chemistry()
-        elif previous_model is not None and previous_model.has_attr(
-            "next_starting_chemistry_array"
-        ):
-            # All models must use the same hard-coded PHYSICAL_PARAMETERS from constants.py
-            # If previous_model was loaded from a legacy file with different parameters,
-            # that's a compatibility issue that should have been caught during load.
-            self._create_starting_array(previous_model.next_starting_chemistry_array)
+        else:
+            self._create_starting_array(starting_chemistry)
 
         self.give_start_abund = self.starting_chemistry_array is not None
         assert not np.all(self.starting_chemistry_array == 0.0), (
@@ -2060,19 +2054,29 @@ class AbstractModel(ABC):
 
         return pd.DataFrame(self.se_stats_array[:, point, :], columns=columns)
 
-    def _create_starting_array(self, starting_chemistry: np.ndarray | None) -> None:
+    def _create_starting_array(
+        self, starting_chemistry: np.ndarray | AbstractModel | None
+    ) -> None:
         if starting_chemistry is None:
             self.starting_chemistry_array = None
-        else:
-            if len(np.shape(starting_chemistry)) == 1:
-                starting_chemistry = starting_chemistry[np.newaxis, :]
-            # For shared memory:
-            (
-                self._shm_handles["starting_chemistry_array"],
-                self._shm_desc["starting_chemistry_array"],
-                self.starting_chemistry_array,
-            ) = self._create_shared_memory_allocation(np.shape(starting_chemistry))
-            np.copyto(self.starting_chemistry_array, starting_chemistry, casting="no")
+            return
+
+        if isinstance(starting_chemistry, AbstractModel) and hasattr(
+            starting_chemistry, "next_starting_chemistry_array"
+        ):
+            starting_chemistry = np.asarray(
+                starting_chemistry.next_starting_chemistry_array
+            )
+
+        if len(np.shape(starting_chemistry)) == 1:
+            starting_chemistry = starting_chemistry[np.newaxis, :]
+        # For shared memory:
+        (
+            self._shm_handles["starting_chemistry_array"],
+            self._shm_desc["starting_chemistry_array"],
+            self.starting_chemistry_array,
+        ) = self._create_shared_memory_allocation(np.shape(starting_chemistry))
+        np.copyto(self.starting_chemistry_array, starting_chemistry, casting="no")
         return
 
     # /Creation of arrays
@@ -2190,11 +2194,9 @@ class Cloud(AbstractModel):
         out_species (list | None): List of species whose abundances at the end of the model are
             returned. If None, defaults to `uclchem.constants.default_elements_to_check`.
             Default = None.
-        starting_chemistry (np.ndarray | None): Array containing the starting abundances to use for
-            the UCLCHEM model. Defaults to None.
-        previous_model (AbstractModel | None): Model object, a class that inherited from AbstractModel,
-            to use for the starting abundances of the new UCLCHEM model that will be run.
-            Defaults to None.
+        starting_chemistry (np.ndarray | AbstractModel | None): Array containing the starting abundances
+            to use for the UCLCHEM model or :class:`AbstractModel` instance to take final
+            abundances from. Defaults to None.
         timepoints (int): Integer value of how many timesteps should be calculated before
             aborting the UCLCHEM model. Defaults to `uclchem.constants.TIMEPOINTS`.
         debug (bool): Flag if extra debug information should be printed to the terminal.
@@ -2208,8 +2210,7 @@ class Cloud(AbstractModel):
         self,
         param_dict: dict | None = None,
         out_species: list[str] | None = None,
-        starting_chemistry: np.ndarray | None = None,
-        previous_model: AbstractModel | None = None,
+        starting_chemistry: np.ndarray | AbstractModel | None = None,
         timepoints: int = TIMEPOINTS,
         debug: bool = False,
         read_file: str = None,
@@ -2224,7 +2225,6 @@ class Cloud(AbstractModel):
             param_dict=param_dict,
             out_species_list=out_species,
             starting_chemistry=starting_chemistry,
-            previous_model=previous_model,
             timepoints=timepoints,
             debug=debug,
             read_file=read_file,
@@ -2303,11 +2303,9 @@ class Collapse(AbstractModel):
         out_species (list | None): List of species whose abundances at the end of the model are
             returned. If None, defaults to `uclchem.constants.default_elements_to_check`.
             Default = None.
-        starting_chemistry (np.ndarray | None): Array containing the starting abundances to use for
-            the UCLCHEM model. Defaults to None.
-        previous_model (AbstractModel | None): Model object, a class that inherited from AbstractModel,
-            to use for the starting abundances of the new UCLCHEM model that will be run.
-            Defaults to None.
+        starting_chemistry (np.ndarray | AbstractModel | None): Array containing the starting abundances
+            to use for the UCLCHEM model or :class:`AbstractModel` instance to take final
+            abundances from. Defaults to None.
         timepoints (int): Integer value of how many timesteps should be calculated before
             aborting the UCLCHEM model. Defaults to `uclchem.constants.TIMEPOINTS`.
         debug (bool): Flag if extra debug information should be printed to the terminal.
@@ -2331,8 +2329,7 @@ class Collapse(AbstractModel):
         collapse: Literal["BE1.1", "BE4", "filament", "ambipolar"] = "BE1.1",
         param_dict: dict | None = None,
         out_species: list[str] | None = None,
-        starting_chemistry: np.ndarray | None = None,
-        previous_model: AbstractModel | None = None,
+        starting_chemistry: np.ndarray | AbstractModel | None = None,
         timepoints: int = TIMEPOINTS,
         debug: bool = False,
         read_file: str = None,
@@ -2425,7 +2422,6 @@ class Collapse(AbstractModel):
             param_dict=param_dict,
             out_species_list=out_species,
             starting_chemistry=starting_chemistry,
-            previous_model=previous_model,
             timepoints=timepoints,
             debug=debug,
             read_file=read_file,
@@ -2512,11 +2508,9 @@ class PrestellarCore(AbstractModel):
         out_species (list | None): List of species whose abundances at the end of the model are
             returned. If None, defaults to `uclchem.constants.default_elements_to_check`.
             Default = None.
-        starting_chemistry (np.ndarray | None): Array containing the starting abundances to use for
-            the UCLCHEM model. Defaults to None.
-        previous_model (AbstractModel | None): Model object, a class that inherited from AbstractModel,
-            to use for the starting abundances of the new UCLCHEM model that will be run.
-            Defaults to None.
+        starting_chemistry (np.ndarray | AbstractModel | None): Array containing the starting abundances
+            to use for the UCLCHEM model or :class:`AbstractModel` instance to take final
+            abundances from. Defaults to None.
         timepoints (int): Integer value of how many timesteps should be calculated before
             aborting the UCLCHEM model. Defaults to `uclchem.constants.TIMEPOINTS`.
         debug (bool): Flag if extra debug information should be printed to the terminal.
@@ -2532,8 +2526,7 @@ class PrestellarCore(AbstractModel):
         max_temperature: float = 300.0,
         param_dict: dict | None = None,
         out_species: list[str] | None = None,
-        starting_chemistry: np.ndarray | None = None,
-        previous_model: AbstractModel | None = None,
+        starting_chemistry: np.ndarray | AbstractModel | None = None,
         timepoints: int = TIMEPOINTS,
         debug: bool = False,
         read_file: str = None,
@@ -2552,7 +2545,6 @@ class PrestellarCore(AbstractModel):
             param_dict=param_dict,
             out_species_list=out_species,
             starting_chemistry=starting_chemistry,
-            previous_model=previous_model,
             timepoints=timepoints,
             debug=debug,
             read_file=read_file,
@@ -2647,11 +2639,9 @@ class CShock(AbstractModel):
         out_species (list | None): List of species whose abundances at the end of the model are
             returned. If None, defaults to `uclchem.constants.default_elements_to_check`.
             Default = None.
-        starting_chemistry (np.ndarray | None): Array containing the starting abundances to use for
-            the UCLCHEM model. Defaults to None.
-        previous_model (AbstractModel | None): Model object, a class that inherited from AbstractModel,
-            to use for the starting abundances of the new UCLCHEM model that will be run.
-            Defaults to None.
+        starting_chemistry (np.ndarray | AbstractModel | None): Array containing the starting abundances
+            to use for the UCLCHEM model or :class:`AbstractModel` instance to take final
+            abundances from. Defaults to None.
         timepoints (int): Integer value of how many timesteps should be calculated before
             aborting the UCLCHEM model. Defaults to `uclchem.constants.TIMEPOINTS`.
         debug (bool): Flag if extra debug information should be printed to the terminal.
@@ -2668,8 +2658,7 @@ class CShock(AbstractModel):
         minimum_temperature: float = 0.0,
         param_dict: dict | None = None,
         out_species: list[str] | None = None,
-        starting_chemistry: np.ndarray | None = None,
-        previous_model: AbstractModel | None = None,
+        starting_chemistry: np.ndarray | AbstractModel | None = None,
         timepoints: int = TIMEPOINTS,
         debug: bool = False,
         read_file: str = None,
@@ -2688,7 +2677,6 @@ class CShock(AbstractModel):
             param_dict=param_dict,
             out_species_list=out_species,
             starting_chemistry=starting_chemistry,
-            previous_model=previous_model,
             timepoints=timepoints,
             debug=debug,
             read_file=read_file,
@@ -2783,11 +2771,9 @@ class JShock(AbstractModel):
         out_species (list | None): List of species whose abundances at the end of the model are
             returned. If None, defaults to `uclchem.constants.default_elements_to_check`.
             Default = None.
-        starting_chemistry (np.ndarray | None): Array containing the starting abundances to use for
-            the UCLCHEM model. Defaults to None.
-        previous_model (AbstractModel | None): Model object, a class that inherited from AbstractModel,
-            to use for the starting abundances of the new UCLCHEM model that will be run.
-            Defaults to None.
+        starting_chemistry (np.ndarray | AbstractModel | None): Array containing the starting abundances
+            to use for the UCLCHEM model or :class:`AbstractModel` instance to take final
+            abundances from. Defaults to None.
         timepoints (int): Integer value of how many timesteps should be calculated before
             aborting the UCLCHEM model. Defaults to `uclchem.constants.TIMEPOINTS`.
         debug (bool): Flag if extra debug information should be printed to the terminal.
@@ -2802,8 +2788,7 @@ class JShock(AbstractModel):
         shock_vel: float = 10.0,
         param_dict: dict | None = None,
         out_species: list[str] | None = None,
-        starting_chemistry: np.ndarray | None = None,
-        previous_model: AbstractModel | None = None,
+        starting_chemistry: np.ndarray | AbstractModel | None = None,
         timepoints: int = TIMEPOINTS,
         debug: bool = False,
         read_file: str = None,
@@ -2822,7 +2807,6 @@ class JShock(AbstractModel):
             param_dict=param_dict,
             out_species_list=out_species,
             starting_chemistry=starting_chemistry,
-            previous_model=previous_model,
             timepoints=timepoints,
             debug=debug,
             read_file=read_file,
@@ -2911,11 +2895,9 @@ class Postprocess(AbstractModel):
         out_species (list | None): List of species whose abundances at the end of the model are
             returned. If None, defaults to `uclchem.constants.default_elements_to_check`.
             Default = None.
-        starting_chemistry (np.ndarray | None): Array containing the starting abundances
-            to use for the UCLCHEM model. Defaults to None.
-        previous_model (AbstractModel | None): Model object, a class that inherited from AbstractModel,
-            to use for the starting abundances of the new UCLCHEM model that will be run.
-            Defaults to None.
+        starting_chemistry (np.ndarray | AbstractModel | None): Array containing the starting abundances
+            to use for the UCLCHEM model or :class:`AbstractModel` instance to take final
+            abundances from. Defaults to None.
         time_array (np.ndarray | None): Represents the time grid to be used for the model.
             This sets the target timesteps for which outputs will be stored.
         density_array (np.ndarray | None): Represents the value of the density at different
@@ -2947,8 +2929,7 @@ class Postprocess(AbstractModel):
         self,
         param_dict: dict | None = None,
         out_species: list[str] | None = None,
-        starting_chemistry: np.ndarray | None = None,
-        previous_model: AbstractModel | None = None,
+        starting_chemistry: np.ndarray | AbstractModel | None = None,
         time_array: np.ndarray | None = None,
         density_array: np.ndarray | None = None,
         gas_temperature_array: np.ndarray | None = None,
@@ -2980,7 +2961,6 @@ class Postprocess(AbstractModel):
             param_dict=param_dict,
             out_species_list=out_species,
             starting_chemistry=starting_chemistry,
-            previous_model=previous_model,
             timepoints=int(1.5 * len(time_array)),
             debug=debug,
             read_file=read_file,
@@ -3129,11 +3109,9 @@ class Model(AbstractModel):
         out_species (list | None): List of species whose abundances at the end of the model are
             returned. If None, defaults to `uclchem.constants.default_elements_to_check`.
             Default = None.
-        starting_chemistry (np.ndarray | None): Array containing the starting abundances to use for
-            the UCLCHEM model. Defaults to None.
-        previous_model (AbstractModel | None): Model object, a class that inherited from
-            AbstractModel, to use for the starting abundances of the new UCLCHEM model
-            that will be run. Defaults to None.
+        starting_chemistry (np.ndarray | AbstractModel | None): Array containing the starting abundances
+            to use for the UCLCHEM model or :class:`AbstractModel` instance to take final
+            abundances from. Defaults to None.
         time_array (np.ndarray | None): Represents the time grid to be used for the model.
             This sets the target timesteps for which outputs will be stored.
         density_array (np.ndarray | None): Represents the value of the density at different
@@ -3157,8 +3135,7 @@ class Model(AbstractModel):
         self,
         param_dict: dict | None = None,
         out_species: list[str] | None = None,
-        starting_chemistry: np.ndarray | None = None,
-        previous_model: AbstractModel | None = None,
+        starting_chemistry: np.ndarray | AbstractModel | None = None,
         time_array: np.ndarray | None = None,
         density_array: np.ndarray | None = None,
         gas_temperature_array: np.ndarray | None = None,
@@ -3185,7 +3162,6 @@ class Model(AbstractModel):
             param_dict=param_dict,
             out_species_list=out_species,
             starting_chemistry=starting_chemistry,
-            previous_model=previous_model,
             timepoints=int(1.5 * len(time_array)),
             debug=debug,
             read_file=read_file,
@@ -3381,13 +3357,13 @@ class SequentialRunner:
                     tmp_model = REGISTRY[model_type](
                         **model_dict,
                         run_type=self.run_type,
-                        previous_model=previous_model,
+                        starting_chemistry=previous_model,
                     )
                 else:
                     tmp_model = REGISTRY[model_type](
                         **model_dict,
                         run_type=self.run_type,
-                        previous_model=previous_model,
+                        starting_chemistry=previous_model,
                     )
 
                 if self.run_type == "external":
@@ -4075,7 +4051,9 @@ class GridRunner:
 
                 # grid_param_dict contains the param_dict values of the next model to run.
                 grid_param_dict = {
-                    k: v if not isinstance(v, float) else (v.item() if hasattr(v, 'item') else v)
+                    k: v
+                    if not isinstance(v, float)
+                    else (v.item() if hasattr(v, "item") else v)
                     for k, v in zip(param_keys, combo)
                     if k in full_parameters["param_dict"]
                 }

--- a/tests/test_1d_radiative_transfer.py
+++ b/tests/test_1d_radiative_transfer.py
@@ -709,7 +709,7 @@ class TestOOModelChaining1D:
     """Test chaining 1D models together with OO interface."""
 
     def test_oo_chain_1d_models(self, base_1d_params):
-        """Test running sequential 1D models using previous_model."""
+        """Test running sequential 1D models using starting_chemistry AbstractModel."""
         # Phase 1: Initial evolution
         params1 = base_1d_params.copy()
         params1["finalTime"] = 5.0e4
@@ -729,7 +729,7 @@ class TestOOModelChaining1D:
         model2 = uclchem.model.Cloud(
             param_dict=params2,
             out_species=["CO", "H2O"],
-            previous_model=model1,
+            starting_chemistry=model1,
             timepoints=2500,
         )
         model2.check_error()


### PR DESCRIPTION
See #168 