### PR TITLE
Fix RuntimeNetwork for ice stuff

### DIFF
--- a/src/uclchem/advanced/fortran_metadata.yaml
+++ b/src/uclchem/advanced/fortran_metadata.yaml
@@ -11,6 +11,7 @@ fortran_parameters:
   - wave2
   network:
   - atomcounts
+  - bindingenergy
   - bulklist
   - bulkswapreacs
   - crphotreacs
@@ -22,6 +23,7 @@ fortran_parameters:
   - desoh2reacs
   - desorbreacs
   - deuvcrreacs
+  - diffusionbarrier
   - edreacs
   - enablechemicalheating
   - erdescorrespondingerreacs

--- a/src/uclchem/advanced/fortran_metadata.yaml
+++ b/src/uclchem/advanced/fortran_metadata.yaml
@@ -11,7 +11,6 @@ fortran_parameters:
   - wave2
   network:
   - atomcounts
-  - bindingenergy
   - bulklist
   - bulkswapreacs
   - crphotreacs
@@ -23,7 +22,6 @@ fortran_parameters:
   - desoh2reacs
   - desorbreacs
   - deuvcrreacs
-  - diffusionbarrier
   - edreacs
   - enablechemicalheating
   - erdescorrespondingerreacs

--- a/src/uclchem/advanced/runtime_network.py
+++ b/src/uclchem/advanced/runtime_network.py
@@ -381,9 +381,8 @@ class RuntimeNetwork(BaseNetwork):
     def _cache_initial_state(self):
         """Cache the initial state of all modifiable Fortran parameters.
 
-        Allows fast reset without re-reading CSV files. Caches:
-        - Reaction parameters: alpha, beta, gama
-        - Species parameters: bindingenergy, diffusionbarrier
+        Allows fast reset without re-reading CSV files.
+        Caches everything in :data:`RuntimeNetwork._ARRAYS_TO_CACHE`.
 
         """
         self._initial_arrays = {}

--- a/src/uclchem/advanced/runtime_network.py
+++ b/src/uclchem/advanced/runtime_network.py
@@ -70,6 +70,8 @@ class RuntimeNetwork(BaseNetwork):
     # (GAR, PHOTON, CRP, CRPHOT, etc.) instead of species indices
     _FORTRAN_KEYWORD_SENTINEL = 9999
 
+    _ARRAYS_TO_CACHE = {"alpha", "beta", "gama", "bindingenergy", "diffusionbarrier"}
+
     def __init__(self):
         """Initialize RuntimeNetwork by loading the compiled Fortran module.
 
@@ -181,11 +183,13 @@ class RuntimeNetwork(BaseNetwork):
             mass = float(self._fortran.mass[i])
 
             # Optional fields with bounds checking
-            binding_energy = (
-                float(self._fortran.bindingenergy[i])
-                if i < len(self._fortran.bindingenergy)
-                else 0.0
-            )
+            if name.startswith("#") or name.startswith("@"):
+                ice_list_index = self._get_ice_list_index(name)
+                binding_energy = float(self._fortran.bindingenergy[ice_list_index])
+                diffusion_barrier = float(self._fortran.diffusionbarrier[ice_list_index])
+            else:
+                binding_energy = 0.0
+                diffusion_barrier = 0.0
 
             # Formation enthalpy if available
             enthalpy = (
@@ -198,9 +202,20 @@ class RuntimeNetwork(BaseNetwork):
             # Create Species object (CSV-style row format)
             # [
             #    NAME, MASS, BINDING_ENERGY, SOLID_FRACTION,
-            #    MONO_FRACTION, VOLCANO_FRACTION, ENTHALPY,
+            #    MONO_FRACTION, VOLCANO_FRACTION, ENTHALPY, DIFFUSION_PREFACTOR,
+            #    DIFFUSION_BARRIER
             # ]
-            species_row = [name, mass, binding_energy, 1.0, 1.0, 0.0, enthalpy]
+            species_row = [
+                name,
+                mass,
+                binding_energy,
+                1.0,
+                1.0,
+                0.0,
+                enthalpy,
+                0.0,
+                diffusion_barrier,
+            ]
             species = Species(species_row)
 
             species_dict[name] = species
@@ -368,12 +383,12 @@ class RuntimeNetwork(BaseNetwork):
 
         Allows fast reset without re-reading CSV files. Caches:
         - Reaction parameters: alpha, beta, gama
-        - Species parameters: bindingenergy
+        - Species parameters: bindingenergy, diffusionbarrier
+
         """
-        self._initial_alpha = np.copy(self._fortran.alpha)
-        self._initial_beta = np.copy(self._fortran.beta)
-        self._initial_gama = np.copy(self._fortran.gama)
-        self._initial_bindingenergy = np.copy(self._fortran.bindingenergy)
+        self._initial_arrays = {}
+        for array_name in self._ARRAYS_TO_CACHE:
+            self._initial_arrays[array_name] = np.copy(getattr(self._fortran, array_name))
 
     # ========================================================================
     # Properties (NetworkABC Implementation)
@@ -532,6 +547,26 @@ class RuntimeNetwork(BaseNetwork):
     # Parameter Modification Methods (NetworkABC Implementation)
     # ========================================================================
 
+    def _get_species_index(self, specie: str) -> int:
+        # Find species index (1-based)
+        species_names = [
+            self._get_species_name(i + 1) for i in range(len(self._fortran.specname))
+        ]
+
+        try:
+            species_idx = species_names.index(specie)
+            return species_idx
+        except ValueError:
+            raise KeyError(f"Species '{specie}' not found in network")
+
+    def _get_ice_list_index(self, specie: str) -> int:
+        species_idx = self._get_species_index(specie)
+        for ice_list_index, species_index in enumerate(self._fortran.icelist):
+            if species_index == species_idx + 1:
+                return ice_list_index
+        msg = f"Species '{specie}' with index {species_idx} (base-0) not found in iceList"
+        raise KeyError(msg)
+
     def change_binding_energy(self, specie: str, new_binding_energy: float) -> None:
         """Change binding energy of a species (modifies Fortran array).
 
@@ -543,22 +578,24 @@ class RuntimeNetwork(BaseNetwork):
             KeyError: If species not found
 
         """
-        # Find species index (1-based)
-        species_names = [
-            self._get_species_name(i + 1) for i in range(len(self._fortran.specname))
-        ]
-
-        try:
-            species_idx = species_names.index(specie)
-        except ValueError:
-            raise KeyError(f"Species '{specie}' not found in network")
+        ice_list_idx = self._get_ice_list_index(specie)
 
         # Modify Fortran array (0-based)
-        self._fortran.bindingenergy[species_idx] = float(new_binding_energy)
+        self._fortran.bindingenergy[ice_list_idx] = float(new_binding_energy)
 
         # Update cached species object
         if specie in self._species_dict:
             self._species_dict[specie].set_binding_energy(new_binding_energy)
+
+    def change_diffusion_barrier(self, specie: str, new_diffusion_barrier: float) -> None:
+        ice_list_idx = self._get_ice_list_index(specie)
+
+        # Modify Fortran array (0-based)
+        self._fortran.diffusionbarrier[ice_list_idx] = float(new_diffusion_barrier)
+
+        # Update cached species object
+        if specie in self._species_dict:
+            self._species_dict[specie].set_diffusion_barrier(new_diffusion_barrier)
 
     def change_reaction_barrier(self, reaction: Reaction, barrier: float) -> None:
         """Change activation barrier of a reaction (modifies Fortran gamma).
@@ -653,10 +690,8 @@ class RuntimeNetwork(BaseNetwork):
             >>> network.reset_to_initial_state()  # Restores original alpha
 
         """
-        np.copyto(self._fortran.alpha, self._initial_alpha)
-        np.copyto(self._fortran.beta, self._initial_beta)
-        np.copyto(self._fortran.gama, self._initial_gama)
-        np.copyto(self._fortran.bindingenergy, self._initial_bindingenergy)
+        for array_name, array in self._initial_arrays.items():
+            np.copyto(getattr(self._fortran, array_name), array)
 
         # Reload species and reactions to sync cached objects
         self._species_dict = self._load_species_from_fortran()

--- a/src/uclchem/advanced/runtime_network.py
+++ b/src/uclchem/advanced/runtime_network.py
@@ -40,7 +40,7 @@ class RuntimeNetwork(BaseNetwork):
     is fixed, but parameters can be modified.
 
     To "remove" a reaction: set its alpha parameter to 0.0 using disable_reaction().
-    To reset changes: call reset_to_initial_state().
+    To reset changes: call :meth:`reset_to_initial_state`.
 
     Examples:
         >>> # Load runtime network
@@ -52,13 +52,30 @@ class RuntimeNetwork(BaseNetwork):
 
         >>> # Modify parameters
         >>> network.modify_reaction_parameters(0, alpha=1e-10, beta=2.0)
-        >>> network.change_binding_energy("H2O", 5773.0)
+        >>> network.change_binding_energy("#H2O", 5773.0)
 
         >>> # Disable a reaction
         >>> network.disable_reaction(5)
 
         >>> # Reset when done
         >>> network.reset_to_initial_state()
+
+        You can use this to do a sensitivity analysis in a simple way.
+
+        >>> # Artificially set a higher diffusion barrier of atomic hydrogen
+        >>> network.change_diffusion_barrier("#H", 600)
+        >>>
+        >>> # Run a model at the increased hydrogen diffusion barrier
+        >>> import uclchem
+        >>> param_dict = {"initialDens": 1e5, "initialTemp": 10, "finalTime": 1e5}
+        >>> high_diffusion_barrier_model = uclchem.model.Cloud(param_dict=param_dict)
+        >>>
+        >>> # Reset to initial state, and then run a "standard" model
+        >>> network.reset_to_initial_state()
+        >>> regular_diffusion_barrier_model = uclchem.model.Cloud(param_dict=param_dict)
+        >>>
+        >>> # Do some analysis to see the effect of a higher hydrogen diffusion barrier
+        >>> # ...
 
     Thread Safety Warning:
         Modifies global Fortran module state. NOT thread-safe.

--- a/src/uclchem/advanced/worker_state.py
+++ b/src/uclchem/advanced/worker_state.py
@@ -22,8 +22,7 @@ from uclchemwrap import network as network_module
 
 from uclchem.advanced.runtime_network import RuntimeNetwork
 
-from .constants import (FILE_PATH_PARAMETERS, FORTRAN_PARAMETERS,
-                        INTERNAL_PARAMETERS)
+from .constants import FILE_PATH_PARAMETERS, FORTRAN_PARAMETERS, INTERNAL_PARAMETERS
 
 # Module names mirroring GeneralSettings._discover_modules()
 _MODULE_NAMES = [

--- a/src/uclchem/advanced/worker_state.py
+++ b/src/uclchem/advanced/worker_state.py
@@ -20,7 +20,10 @@ from uclchemwrap import f2py_constants as f2py_constants_module
 from uclchemwrap import heating as heating_module
 from uclchemwrap import network as network_module
 
-from .constants import FILE_PATH_PARAMETERS, FORTRAN_PARAMETERS, INTERNAL_PARAMETERS
+from uclchem.advanced.runtime_network import RuntimeNetwork
+
+from .constants import (FILE_PATH_PARAMETERS, FORTRAN_PARAMETERS,
+                        INTERNAL_PARAMETERS)
 
 # Module names mirroring GeneralSettings._discover_modules()
 _MODULE_NAMES = [
@@ -56,6 +59,8 @@ _MODULES_SKIP_0D = frozenset(
         "surfacereactions",  # grain/surface constants – all PARAMETERs
     }
 )
+
+_NETWORK_ARRAYS_TO_TAKE_SNAPSHOT_OF = RuntimeNetwork._ARRAYS_TO_CACHE
 
 
 def create_snapshot() -> dict[str, Any]:
@@ -145,10 +150,8 @@ def create_snapshot() -> dict[str, Any]:
 
     # --- Network state (rate parameters + binding energies) ---
     snapshot["network"] = {
-        "alpha": np.copy(network_module.alpha),
-        "beta": np.copy(network_module.beta),
-        "gama": np.copy(network_module.gama),
-        "bindingenergy": np.copy(network_module.bindingenergy),
+        array_name: np.copy(getattr(network_module, array_name))
+        for array_name in _NETWORK_ARRAYS_TO_TAKE_SNAPSHOT_OF
     }
 
     return snapshot
@@ -205,14 +208,8 @@ def restore_snapshot(snapshot: dict[str, Any]) -> None:
 
     # --- Network state ---
     net = snapshot.get("network", {})
-    if "alpha" in net:
-        np.copyto(network_module.alpha, net["alpha"])
-    if "beta" in net:
-        np.copyto(network_module.beta, net["beta"])
-    if "gama" in net:
-        np.copyto(network_module.gama, net["gama"])
-    if "bindingenergy" in net:
-        np.copyto(network_module.bindingenergy, net["bindingenergy"])
+    for array_name, array in net.items():
+        np.copyto(getattr(network_module, array_name), array)
 
 
 def _pool_initializer(snapshot: dict[str, Any]) -> None:

--- a/src/uclchem/advanced/worker_state.py
+++ b/src/uclchem/advanced/worker_state.py
@@ -75,7 +75,7 @@ def create_snapshot() -> dict[str, Any]:
       (excluding PARAMETERs, INTERNAL, FILE_PATH, and arrays).
     * ``"heating"`` – heating/cooling boolean arrays, scalars, and coolant
       configuration.
-    * ``"network"`` – reaction-rate and binding-energy arrays.
+    * ``"network"`` – Everything in :data:`_NETWORK_ARRAYS_TO_TAKE_SNAPSHOT_OF`.
 
     Returns:
         Fully picklable dict suitable for passing to :func:`restore_snapshot`.

--- a/src/uclchem/model.py
+++ b/src/uclchem/model.py
@@ -83,6 +83,7 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
+
 # /UCLCHEM related imports
 # Multiprocessing imports
 import multiprocessing as mp
@@ -103,19 +104,28 @@ import numpy as np
 import pandas as pd
 import uclchemwrap
 import xarray as xr
+
 # UCLCHEM related imports
 from uclchemwrap import uclchemwrap as wrap
 
 from uclchem._coolant_utils import load_coolant_level_names
 from uclchem._fortran_capture import capture_fortran_output
 from uclchem.analysis import check_element_conservation
-from uclchem.constants import (DVODE_STAT_NAMES, N_DVODE_STATS,
-                               N_PHYSICAL_PARAMETERS, N_SE_STATS_PER_COOLANT,
-                               N_TOTAL_LEVELS, NCOOLANTS, PHYSICAL_PARAMETERS,
-                               SE_STAT_NAMES, TIMEPOINTS,
-                               default_elements_to_check,
-                               default_param_dictionary, n_reactions,
-                               n_species)
+from uclchem.constants import (
+    DVODE_STAT_NAMES,
+    N_DVODE_STATS,
+    N_PHYSICAL_PARAMETERS,
+    N_SE_STATS_PER_COOLANT,
+    N_TOTAL_LEVELS,
+    NCOOLANTS,
+    PHYSICAL_PARAMETERS,
+    SE_STAT_NAMES,
+    TIMEPOINTS,
+    default_elements_to_check,
+    default_param_dictionary,
+    n_reactions,
+    n_species,
+)
 from uclchem.plot import create_abundance_plot, plot_species
 from uclchem.utils import UCLCHEM_ROOT_DIR, SuccessFlag
 
@@ -3722,8 +3732,7 @@ class GridRunner:
 
         # Capture advanced settings so spawned workers start with the same
         # Fortran module state as the coordinator process.
-        from uclchem.advanced.worker_state import (_pool_initializer,
-                                                   create_snapshot)
+        from uclchem.advanced.worker_state import _pool_initializer, create_snapshot
 
         snapshot = create_snapshot()
 

--- a/src/uclchem/model.py
+++ b/src/uclchem/model.py
@@ -83,7 +83,6 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
-
 # /UCLCHEM related imports
 # Multiprocessing imports
 import multiprocessing as mp
@@ -104,30 +103,19 @@ import numpy as np
 import pandas as pd
 import uclchemwrap
 import xarray as xr
-
 # UCLCHEM related imports
 from uclchemwrap import uclchemwrap as wrap
 
 from uclchem._coolant_utils import load_coolant_level_names
 from uclchem._fortran_capture import capture_fortran_output
-from uclchem.analysis import (
-    check_element_conservation,
-)
-from uclchem.constants import (
-    DVODE_STAT_NAMES,
-    N_DVODE_STATS,
-    N_PHYSICAL_PARAMETERS,
-    N_SE_STATS_PER_COOLANT,
-    N_TOTAL_LEVELS,
-    NCOOLANTS,
-    PHYSICAL_PARAMETERS,
-    SE_STAT_NAMES,
-    TIMEPOINTS,
-    default_elements_to_check,
-    default_param_dictionary,
-    n_reactions,
-    n_species,
-)
+from uclchem.analysis import check_element_conservation
+from uclchem.constants import (DVODE_STAT_NAMES, N_DVODE_STATS,
+                               N_PHYSICAL_PARAMETERS, N_SE_STATS_PER_COOLANT,
+                               N_TOTAL_LEVELS, NCOOLANTS, PHYSICAL_PARAMETERS,
+                               SE_STAT_NAMES, TIMEPOINTS,
+                               default_elements_to_check,
+                               default_param_dictionary, n_reactions,
+                               n_species)
 from uclchem.plot import create_abundance_plot, plot_species
 from uclchem.utils import UCLCHEM_ROOT_DIR, SuccessFlag
 
@@ -276,6 +264,8 @@ def load_model(
         opened_file = True
 
     if name not in file_obj:
+        if opened_file:
+            file_obj.close()
         raise Exception(f"model {name} was not found in the save file that was passed.")
     model_group = file_obj[name]
     coords = {}
@@ -3732,7 +3722,8 @@ class GridRunner:
 
         # Capture advanced settings so spawned workers start with the same
         # Fortran module state as the coordinator process.
-        from uclchem.advanced.worker_state import _pool_initializer, create_snapshot
+        from uclchem.advanced.worker_state import (_pool_initializer,
+                                                   create_snapshot)
 
         snapshot = create_snapshot()
 


### PR DESCRIPTION
RuntimeNetwork was broken before if you tried to set a binding energy, because it was just indexing by the species index, but bindingEnergy array in fortran should be indexed by the iceListIndex.

Added setting the diffusion barrier of species. 

Added easier addition of new arrays to cache of `RuntimeNetwork` by just setting all the things to cache in `_NETWORK_ARRAYS_TO_CACHE`. This is also used by `create_snapshot`, so that they are always the same.