### PR TITLE
Fix endAtFinalDensity not working, and make sure that if a finalDens …

### DIFF
--- a/src/fortran_src/physics-core.f90
+++ b/src/fortran_src/physics-core.f90
@@ -106,9 +106,9 @@ CONTAINS
             write(*,*) "Error: improvedH2CRPDissociation requires cosmicRayAttentuation to also be True"
             RETURN
         END IF
-        IF (finalDens .lt. initialDens) THEN
+        IF ((freefall) .and. (finalDens .lt. initialDens)) THEN
             successFlag=-1
-            WRITE(*,*) "Error: finalDens (", finalDens, ") is less than initialDens (", initialDens, ")"
+            WRITE(*,*) "Error: freefall finalDens (", finalDens, ") is less than initialDens (", initialDens, ")"
             RETURN
         END IF
 

--- a/src/fortran_src/physics-core.f90
+++ b/src/fortran_src/physics-core.f90
@@ -106,6 +106,11 @@ CONTAINS
             write(*,*) "Error: improvedH2CRPDissociation requires cosmicRayAttentuation to also be True"
             RETURN
         END IF
+        IF (finalDens .lt. initialDens) THEN
+            successFlag=-1
+            WRITE(*,*) "Error: finalDens (", finalDens, ") is less than initialDens (", initialDens, ")"
+            RETURN
+        END IF
 
         !calculate initial column density as distance from core edge to current point * density
         DO dstep=1,points

--- a/src/fortran_src/wrap.f90
+++ b/src/fortran_src/wrap.f90
@@ -876,7 +876,7 @@ CONTAINS
             ELSE
                 ! Non-radiative-transfer path: loop forward through parcels
                 ! Exit loop if density exceeds finalDens (when using density-based stopping)
-                IF ((parcelStoppingMode .ne. 0) .and. (density(dstep) .ge. finalDens)) THEN
+                IF ((parcelStoppingMode .ne. 0) .and. (density(1) .ge. finalDens)) THEN
                     EXIT
                 END IF
                 !loop over parcels, counting from centre out to edge of cloud

--- a/src/fortran_src/wrap.f90
+++ b/src/fortran_src/wrap.f90
@@ -544,8 +544,12 @@ CONTAINS
             RETURN
         END IF
         CALL coreInitializePhysics(successFlag)
+        IF (successFlag .lt. 0) THEN
+            WRITE(*,*) 'Error initializing physics'
+            RETURN
+        END IF
         CALL initializePhysics(successFlag)
-        IF (successFlag .lt. 0) then
+        IF (successFlag .lt. 0) THEN
             WRITE(*,*) 'Error initializing physics'
             RETURN
         END IF
@@ -707,6 +711,12 @@ CONTAINS
         !Initialize core physics first then model specific
         !This allows model to overrule changes made by core
         CALL coreInitializePhysics(successFlag)
+        IF (successFlag .lt. 0) then
+            successFlag=PHYSICS_INIT_ERROR
+            WRITE(*,*) 'Error initializing physics'
+            RETURN
+        END IF
+
         if (present(timegrid)) then
             if (usecoldens) then
                 call modelInitializePhysics(successflag, timegrid,densgrid,radgrid,zetagrid,gtempgrid,&
@@ -755,7 +765,7 @@ CONTAINS
         !loop until the end condition of the model is reached
         ! Main time integration loop
         ! For 1D radiative transfer models, the loop direction and stopping logic differ
-        DO WHILE ((successFlag .eq. 0) .and. (timeInYears < finalTime))
+        DO WHILE ((successFlag .eq. 0) .and. (timeInYears .lt. finalTime))
             dtime = dtime + 1
             currentTimeold=currentTime
             !Each physics module has a subroutine to set the target time from the current time
@@ -774,7 +784,7 @@ CONTAINS
                 flush_rc = c_fflush(C_NULL_PTR) ! TODO: may be redundant with !f2py threadsafe + FLUSH(6)
             END IF
             ! Exit loop if targetTime would exceed finalTime
-            IF (targetTime/SECONDS_PER_YEAR .gt. finalTime) THEN
+            IF ((.not. endAtFinalDensity) .and. (targetTime/SECONDS_PER_YEAR .gt. finalTime)) THEN
                 EXIT
             END IF
 
@@ -866,7 +876,7 @@ CONTAINS
             ELSE
                 ! Non-radiative-transfer path: loop forward through parcels
                 ! Exit loop if density exceeds finalDens (when using density-based stopping)
-                IF (parcelStoppingMode.ne.0 .and. (density(dstep) .ge. finalDens)) THEN
+                IF ((parcelStoppingMode .ne. 0) .and. (density(dstep) .ge. finalDens)) THEN
                     EXIT
                 END IF
                 !loop over parcels, counting from centre out to edge of cloud

--- a/src/uclchem/makerates/io_functions.py
+++ b/src/uclchem/makerates/io_functions.py
@@ -87,6 +87,25 @@ def get_default_coolant_directory(user_specified: str | Path = "") -> str:
     return ""
 
 
+def strip_comments_from_row(row: list[str], comment_char: str = "!") -> list[str]:
+    """Strip comments from a seperated line.
+
+    Args:
+        row (list[str]): List of strings.
+        comment_char (str): Character indicating the beginning of a comment.
+            Default = "!".
+
+    Returns:
+        row (list[str]): List of strings, with the final string adjusted by
+            removing everything after `comment_char` (and any whitespace).
+
+    """
+    if comment_char in row[-1]:
+        row[-1] = row[-1].split(comment_char)[0].strip()
+
+    return row
+
+
 def read_species_file(file_name: str | Path) -> tuple[list[Species], list[Species]]:
     """Read in a Makerates species file.
 
@@ -109,6 +128,7 @@ def read_species_file(file_name: str | Path) -> tuple[list[Species], list[Specie
         for idx, row in enumerate(reader):
             try:
                 if row[0] != "NAME" and "!" not in row[0]:
+                    row = strip_comments_from_row(row)
                     if "@" in row[0]:
                         user_defined_bulk.append(Species(row))
                     else:
@@ -154,6 +174,7 @@ def read_reaction_file(
             for row in reader:
                 if row[0].startswith("#") or row[0].startswith("!"):
                     continue
+                row = strip_comments_from_row(row)
                 reaction_row = row[2:4] + [""] + row[4:8] + row[9:14] + [""]
                 if check_reaction(reaction_row, keep_list):
                     reactions.append(Reaction(reaction_row, reaction_source="UMIST"))
@@ -162,6 +183,7 @@ def read_reaction_file(
             reader = csv.reader(f, delimiter=",", quotechar="|")
             for row in reader:
                 if (len(row) > 1) and (row[0][0] != "!"):
+                    row = strip_comments_from_row(row)
                     if check_reaction(row, keep_list):
                         reactions.append(Reaction(row, reaction_source="UCL"))
                     else:

--- a/src/uclchem/makerates/reaction.py
+++ b/src/uclchem/makerates/reaction.py
@@ -152,7 +152,9 @@ class Reaction:
                 self.set_extrapolation(
                     bool(inputRow[13]) if len(inputRow) > 13 else False
                 )
-                self.set_exothermicity(float(inputRow[14]) if len(inputRow) > 14 else 0.0)
+                self.set_exothermicity(
+                    float(inputRow[14]) if (len(inputRow) > 14 and inputRow[14]) else 0.0
+                )
 
             except IndexError as error:
                 raise ValueError(

--- a/tests/test_collapse_parcel_radius.py
+++ b/tests/test_collapse_parcel_radius.py
@@ -112,21 +112,49 @@ def test_parcel_radius_initial_value_matches_rout():
     )
 
 
-def test_collapse_stops_when_model_reaches_final_density():
-    finalDens = 1e5
+def test_model_stops_end_at_final_density():
+    finalDens = 1e4
+    finalTime = 1e6
     model = uclchem.model.Cloud(
         {
-            "initialDens": 1e3,
+            "initialDens": 8e3,
             "finalDens": finalDens,
-            "finalTime": 5e7,
+            "finalTime": finalTime,
             "endAtFinalDensity": True,
             "freefall": True,
         }
     )
     phys_df, _ = model.get_dataframes(joined=False)
-    assert phys_df["Time"].iloc[-1] < 5e6
+
+    # The model should terminate before it reaches finalTime.
+    assert phys_df["Time"].iloc[-1] < finalTime
+
+    # The model should terminate directly when it reaches finalDens.
     assert phys_df["Density"].iloc[-1] >= finalDens
     assert phys_df["Density"].iloc[-2] < finalDens
+
+
+def test_model_continues_not_end_at_final_density():
+    finalDens = 1e4
+    finalTime = 1e6
+    model = uclchem.model.Cloud(
+        {
+            "initialDens": 8e3,
+            "finalDens": finalDens,
+            "finalTime": finalTime,
+            "endAtFinalDensity": False,
+            "freefall": True,
+        }
+    )
+    phys_df, _ = model.get_dataframes(joined=False)
+
+    # The model should reach the finalTime.
+    assert phys_df["Time"].iloc[-1] == finalTime
+
+    # The model should reach the density, and then stay there after
+    # it reaches it.
+    assert phys_df["Density"].iloc[-1] >= finalDens
+    assert phys_df["Density"].iloc[-2] == phys_df["Density"].iloc[-1]
 
 
 def test_lower_final_than_initial_dens_raises():

--- a/tests/test_collapse_parcel_radius.py
+++ b/tests/test_collapse_parcel_radius.py
@@ -159,7 +159,7 @@ def test_model_continues_not_end_at_final_density():
 
 def test_lower_final_than_initial_dens_raises():
     with pytest.raises(RuntimeError):
-        uclchem.model.Cloud({"initialDens": 1e5, "finalDens": 1e4})
+        uclchem.model.Cloud({"initialDens": 1e5, "finalDens": 1e4, "freefall": True})
 
 
 if __name__ == "__main__":

--- a/tests/test_collapse_parcel_radius.py
+++ b/tests/test_collapse_parcel_radius.py
@@ -112,5 +112,27 @@ def test_parcel_radius_initial_value_matches_rout():
     )
 
 
+def test_collapse_stops_when_model_reaches_final_density():
+    finalDens = 1e5
+    model = uclchem.model.Cloud(
+        {
+            "initialDens": 1e3,
+            "finalDens": finalDens,
+            "finalTime": 5e7,
+            "endAtFinalDensity": True,
+            "freefall": True,
+        }
+    )
+    phys_df, _ = model.get_dataframes(joined=False)
+    assert phys_df["Time"].iloc[-1] < 5e6
+    assert phys_df["Density"].iloc[-1] >= finalDens
+    assert phys_df["Density"].iloc[-2] < finalDens
+
+
+def test_lower_final_than_initial_dens_raises():
+    with pytest.raises(RuntimeError):
+        uclchem.model.Cloud({"initialDens": 1e5, "finalDens": 1e4})
+
+
 if __name__ == "__main__":
     pytest.main(["-v", __file__])

--- a/tests/test_hotcore.py
+++ b/tests/test_hotcore.py
@@ -51,14 +51,14 @@ def _read_coefficients(extra_params: dict) -> tuple[np.ndarray, np.ndarray]:
     params = {**BASE_PARAMS, **extra_params}
 
     cloud = uclchem.model.Cloud(
-        param_dict={**params, "finalTime": 1e3}, out_species=["CO"]
+        param_dict={**params, "finalTime": 10.0}, out_species=["CO"]
     )
     cloud.check_error()
 
     core = uclchem.model.PrestellarCore(
         temp_indx=1,
         max_temperature=300.0,
-        param_dict={**params, "finalTime": 1e2},
+        param_dict={**params, "finalTime": 1.0},
         out_species=["CO"],
         previous_model=cloud,
         run_type="external",
@@ -97,8 +97,8 @@ class TestTempCoefficients1D:
             {
                 "enable_radiative_transfer": True,
                 "points": 2,
-                "rin": 0.001,
-                "rout": 0.05,
+                "rin": 0.1,
+                "rout": 0.5,
                 "density_scale_radius": 0.05,
                 "density_power_index": 2.4,
                 "lum_star": 1e6,


### PR DESCRIPTION
`endAtFinalDensity` was not stopping the model whenever the final density was reached.

You can test this simply by doing 

```python
import uclchem

if __name__ == "__main__":
    phase_1 = {
        "initialDens": 1e2,
        "finalDens": 5e4,
        "endAtFinalDensity": True,
        "freefall": True,
        "initialTemp": 10.0,
        "finalTime": 1e7,
    }
    model = uclchem.model.Cloud(param_dict=phase_1)

    df = model.get_dataframes(joined=True)
    print(df.tail())
```

which should end before 1e7 years, once the final density of 5e4 is reached (around 5.3e6 years).

I do have it now that if `finalTime` and `finalDens` are both set, and `endAtFinalDensity` is True, the model will still stop if `finalTime` is reached before `finalDens` is reached.